### PR TITLE
Make it possible to use the plugin with other, GooBook compatible, tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ AD contacts):
 
 - Alexander Lehmann <afwlehmann@googlemail.com>
 - Matthew Horan <matt@matthoran.com>
+- Matteo Landi <matteo@matteolandi.net>
 
 [1]: https://gitlab.com/goobook/goobook
 [2]: http://contacts.google.com

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ This is a vim plugin to support email address completion by making use of [goobo
 
 Note that this plugin is heavily based on the original [gist][1] by Matthew Horan.
 
+## Configuration
+
+For most users, the default configuration should work just fine; however,
+global variables can be used to change a few things here and there.
+
+`g:goobookrc` can be used to tell the plugin to invoke `goobook` with a custom
+configuration file (i.e. specifying the `-c` flag):
+
+    let g:goobookrc = '~/.goobookrc.account1'
+
+`g:goobookprg` can instead be used to tell the plugin to invoke a completely
+different program than `goobook` (of course you might want to set this to the
+name of a program with compatible output, like [aadbook][4] for querying Azure
+AD contacts):
+
+    let g:goobookprg = 'aadbook'
+
 ## Authors
 
 - Alexander Lehmann <afwlehmann@googlemail.com>
@@ -12,3 +29,4 @@ Note that this plugin is heavily based on the original [gist][1] by Matthew Hora
 [1]: https://gitlab.com/goobook/goobook
 [2]: http://contacts.google.com
 [3]: http://recursivedream.com/blog/2012/auto-completing-google-contacts-in-vim/
+[3]: https://pypi.org/project/aadbook

--- a/plugin/goobook_complete.vim
+++ b/plugin/goobook_complete.vim
@@ -29,7 +29,9 @@ function! goobook_complete#Complete(findstart, base)
         endwhile
         return idx
     else
-        if exists("g:goobookrc")
+        if exists("g:goobookprg")
+            let goobook=g:goobookprg
+        elseif exists("g:goobookrc")
             let goobook="goobook -c " . g:goobookrc
         else
             let goobook="goobook"


### PR DESCRIPTION
This PR add 'g:goobookprg' to let users specify the name of the invoked program